### PR TITLE
Remove unlinked README ToC entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ On `prisma generate` we create:
   - [Examples](#examples)
 - [Usage](#usage)
 - [Disclosures](#disclosures)
-  - [Tested environments](#tested-environments)
   - [Models with only relations](#models-with-only-relations)
   - [BigInt rename](#bigint-rename)
 
@@ -116,7 +115,7 @@ module.exports = {
 
 <details>
   <summary>Click to see all configuration options</summary>
-  
+
   ```ts
   {
     /** Input type generation config */


### PR DESCRIPTION
Removed an extra path in the README table of contents that does not have a corresponding section. Of course, we could change this PR to include that section as well.

Another thing that we could implement is a table of contents generator, such as [this one](https://github.com/jonschlinkert/markdown-toc) (there might be better ones that are more recently maintained, just an idea!).