### PR TITLE
Fix typo in README.md (configuration file)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Disclosures
 
-- We dont use tsconfig paths, because of examples (the prisma generate dont support paths)
+- We don't use tsconfig paths, because of examples (the prisma generate don't support paths)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ module.exports = {
   crud: {
     outputDir: './src/graphql/__generated__/',
     inputsImporter: `import * as Inputs from '@graphql/__generated__/inputs';`,
-    resolversImports: `import prisma from '@lib/prisma';`,
+    resolverImports: `import prisma from '@lib/prisma';`,
     prismaCaller: 'prisma',
   },
   global: {


### PR DESCRIPTION
There's a typo in the configuration example. I copy-pasted the example and coudn't understand why it wasn't working for some time. So here's a fix