### PR TITLE
Update pothos packages of peerDependencies to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The package has been developed and tested up to the following peer dependencies 
 <!-- TODO Maybe we could have some sort of automated pipeline that tests different versions of these peer deps? -->
 
 ```
-"@pothos/core": "^3.41.0",
-"@pothos/plugin-prisma": "^3.65.0",
+"@pothos/core": "^4.0.2",
+"@pothos/plugin-prisma": "^4.0.3"",
 "@prisma/client": "^5.15.1",
 "prisma": "^5.15.1",
 ```

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "prisma-generator-pothos-codegen": "./src/bin.js"
   },
   "peerDependencies": {
-    "@pothos/core": "^3.23.0",
-    "@pothos/plugin-prisma": "^3.37.0",
+    "@pothos/core": "^4.0.2",
+    "@pothos/plugin-prisma": "^4.0.3",
     "@prisma/client": "^5.0.0",
     "prisma": "^5.0.0"
   },


### PR DESCRIPTION
To fix https://github.com/Cauen/prisma-generator-pothos-codegen/issues/73.

https://github.com/Cauen/prisma-generator-pothos-codegen/pull/71 supports pothos v4, so I think the peerDependencies update is just a missing fix.  However, if you haven't updated it intentionally, please ignore this PR. 🙇 